### PR TITLE
Adapt to TSO500

### DIFF
--- a/src/sex_check.py
+++ b/src/sex_check.py
@@ -78,31 +78,35 @@ def get_mapped_reads(filename):
     return chr_1, chr_y, score
 
 
-def get_reported_sex(sample_name):
+def get_reported_sex(bamfile):
     """
-    Extracts the reported sex from a sample name based on its naming convention.
-    e.g. "X12345-GM1234567-23xxxx4-1234-F-12345678"
+    Extracts the reported sex from a filename based on its naming convention.
+    e.g. "X12345-GM1234567-23xxxx4-1234-F-12345678.bam"
+    or "X12345-GM1234567-23xxxx4-1234-F.bam" for TSO500
     Returns 'N' if the sex cannot be determined or is not 'M', 'F', or 'U'.
 
     Args:
-        sample_name (str): The name of the sample, expected to contain the 
+        bamfile (str): The name of the bam file, expected to contain the 
         sex information.
 
     Returns:
         str: The reported sex extracted from the sample name or 'N' if 
         undetermined or invalid.
     """
+    sample_name = os.path.basename(bamfile).split('.')[0]
     parts = sample_name.split('-')
     if len(parts) < 3:
         print(f"{sample_name} is too short to determine sex. Returning N")
         return "N"
 
-    sex = parts[-2].upper()
-    if sex not in ["M", "F", "U"]:
-        print(f"Extracted {sex} from {sample_name} is invalid. Returning N")
-        return "N"
-
-    return sex
+    # check both naming conventions
+    for part in (parts[-2], parts[-1]):
+        sex = part.upper()
+        if sex in ["M", "F", "U"]:
+            return sex
+    
+    print(f"Extracted sex from {sample_name} is invalid. Returning N")
+    return "N"
 
 
 def get_predicted_sex(score, male_threshold, female_threshold):

--- a/src/sex_check.py
+++ b/src/sex_check.py
@@ -62,9 +62,9 @@ def get_mapped_reads(filename):
     with open(filename, encoding="utf-8") as file:
         reader = csv.reader(file, delimiter="\t")
         for line in reader:
-            if line[0] == "1":
+            if line[0] == "1" or line[0] == "chr1":
                 chr_1 = int(line[2])
-            elif line[0] == "Y":
+            elif line[0] == "Y" or line[0] == "chrY":
                 chr_y = int(line[2])
 
     if not chr_1:

--- a/src/sex_check.py
+++ b/src/sex_check.py
@@ -78,22 +78,21 @@ def get_mapped_reads(filename):
     return chr_1, chr_y, score
 
 
-def get_reported_sex(bamfile):
+def get_reported_sex(sample_name):
     """
-    Extracts the reported sex from a filename based on its naming convention.
-    e.g. "X12345-GM1234567-23xxxx4-1234-F-12345678.bam"
-    or "X12345-GM1234567-23xxxx4-1234-F.bam" for TSO500
+    Extracts the reported sex from a sample name based on its naming convention.
+    e.g. "X12345-GM1234567-23xxxx4-1234-F-12345678"
+    or "X12345-GM1234567-23xxxx4-1234-F" for TSO500
     Returns 'N' if the sex cannot be determined or is not 'M', 'F', or 'U'.
 
     Args:
-        bamfile (str): The name of the bam file, expected to contain the 
+        sample_name (str): The name of the sample, expected to contain the 
         sex information.
 
     Returns:
         str: The reported sex extracted from the sample name or 'N' if 
         undetermined or invalid.
     """
-    sample_name = os.path.basename(bamfile).split('.')[0]
     parts = sample_name.split('-')
     if len(parts) < 3:
         print(f"{sample_name} is too short to determine sex. Returning N")
@@ -187,7 +186,7 @@ def main(input_bam, index_file, male_threshold, female_threshold):
     idxstat_output = run_samtools_idxstat(bam_file_name, bam_file_prefix)
     chr_1, chr_y, score = get_mapped_reads(idxstat_output)
     predicted_sex = get_predicted_sex(score, male_threshold, female_threshold)
-    reported_sex = get_reported_sex(bam_file_name)
+    reported_sex = get_reported_sex(bam_file_prefix)
     matched = check_sex_match(reported_sex, predicted_sex)
 
     # format output to mqc json

--- a/src/sex_check.py
+++ b/src/sex_check.py
@@ -181,7 +181,9 @@ def main(input_bam, index_file, male_threshold, female_threshold):
     shutil.move(inputs['index_file_path'][0], os.getcwd())
 
     bam_file_name = inputs['input_bam_name'][0]
-    bam_file_prefix = inputs['input_bam_prefix'][0].rstrip('_markdup')
+    bam_file_prefix = inputs['input_bam_prefix'][0]
+    if bam_file_prefix.endswith('_markdup'):
+        bam_file_prefix = bam_file_prefix[:-len('_markdup')]
 
     idxstat_output = run_samtools_idxstat(bam_file_name, bam_file_prefix)
     chr_1, chr_y, score = get_mapped_reads(idxstat_output)


### PR DESCRIPTION
- add chr1 and chrY in `get_mapped_reads()` for TSO500 bams
- handle TSO500 bam filename convention in `get_reported_sex()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_sex_check/9)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broadened chromosome-name recognition to accept additional common variants for better compatibility with diverse input sources.
  * More flexible sample-name parsing to extract reported sex from alternative naming conventions.
  * Enhanced sex-determination logic checks multiple name segments, returns a clear fallback for ambiguous cases and logs invalid entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->